### PR TITLE
bugfix: make logging output suit set attribute

### DIFF
--- a/nfstats/mainapp/settings_sys.py
+++ b/nfstats/mainapp/settings_sys.py
@@ -70,6 +70,9 @@ def update_globals():
                 'formatter' : 'simple'
             },
         })
+        LOGGING['loggers']['django'].update({
+            'handlers': [SYS_SETTINGS['log_type']],
+        })
         try:
             logging.config.dictConfig(LOGGING)
         except ValueError as e:


### PR DESCRIPTION
Обнаружил, что при выборе file в поле Logging Output, поведение nfstat отличается от задуманного, измение в поле попадает в базу, но лог в файл не пишется. Данное изменение помогает nfstat понимать, каким output пользоваться.